### PR TITLE
Feature/moved emission factor types to url

### DIFF
--- a/emission_source_classifications/api.py
+++ b/emission_source_classifications/api.py
@@ -46,6 +46,7 @@ class ISOCategoryViewSet(viewsets.ReadOnlyModelViewSet):
 class EmissionSourceGroupViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = EmissionSourceGroup.objects.all()
     permission_classes = [permissions.AllowAny]
+    serializer_class = EmissionSourceGroupDetailSerializer
 
     def get_serializer_class(self):
         if self.action == 'list':
@@ -59,14 +60,6 @@ class EmissionSourceGroupViewSet(viewsets.ReadOnlyModelViewSet):
     )
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)
-
-
-    @extend_schema(
-        summary='Retrieve a single emission source group',
-        responses={200: EmissionSourceGroupDetailSerializer}
-    )
-    def retrieve(self, request, *args, **kwargs):
-        return super().retrieve(request, *args, **kwargs)
 
 
     @extend_schema(

--- a/emission_source_classifications/api.py
+++ b/emission_source_classifications/api.py
@@ -52,6 +52,27 @@ class EmissionSourceGroupViewSet(viewsets.ReadOnlyModelViewSet):
             return EmissionSourceGroupListSerializer
         return EmissionSourceGroupDetailSerializer
 
+
+    @extend_schema(
+        summary='Retrieve a list of emission source groups',
+        responses={200: EmissionSourceGroupListSerializer(many=True)}
+    )
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)
+
+
+    @extend_schema(
+        summary='Retrieve a single emission source group',
+        responses={200: EmissionSourceGroupDetailSerializer}
+    )
+    def retrieve(self, request, *args, **kwargs):
+        return super().retrieve(request, *args, **kwargs)
+
+
+    @extend_schema(
+        description='Retrieve emission factor types associated with an emission source group.',
+        responses={200: FactorTypeSerializer(many=True)}
+    )
     @action(detail=True, methods=['get'])
     def emission_factor_types(self, request, pk=None):
         emission_source_group = self.get_object()

--- a/emission_source_classifications/api.py
+++ b/emission_source_classifications/api.py
@@ -43,8 +43,9 @@ class ISOCategoryViewSet(viewsets.ReadOnlyModelViewSet):
 
 
 @extend_schema(tags=['EmissionSourceGroups'])
-class EmissionSourceGroupViewSet(viewsets.ModelViewSet):
+class EmissionSourceGroupViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = EmissionSourceGroup.objects.all()
+    permission_classes = [permissions.AllowAny]
 
     def get_serializer_class(self):
         if self.action == 'list':

--- a/emission_source_classifications/api.py
+++ b/emission_source_classifications/api.py
@@ -12,9 +12,11 @@ from .serializers import (
     QuantificationTypeSerializer,
     GHGScopeSerializer,
     ISOCategorySerializer,
-    EmissionSourceGroupSerializer, CommonEquipmentSerializer, CommonActivitySerializer, CommonProductSerializer,
+    EmissionSourceGroupListSerializer, EmissionSourceGroupDetailSerializer, CommonEquipmentSerializer,  \
+    CommonActivitySerializer, CommonProductSerializer,
     InvestmentSerializer
 )
+from emissions.serializers import FactorTypeSerializer
 from django.utils.translation import gettext_lazy as _
 from django_filters import rest_framework as filters
 
@@ -41,10 +43,20 @@ class ISOCategoryViewSet(viewsets.ReadOnlyModelViewSet):
 
 
 @extend_schema(tags=['EmissionSourceGroups'])
-class EmissionSourceGroupViewSet(viewsets.ReadOnlyModelViewSet):
+class EmissionSourceGroupViewSet(viewsets.ModelViewSet):
     queryset = EmissionSourceGroup.objects.all()
-    serializer_class = EmissionSourceGroupSerializer
-    permission_classes = [permissions.AllowAny]
+
+    def get_serializer_class(self):
+        if self.action == 'list':
+            return EmissionSourceGroupListSerializer
+        return EmissionSourceGroupDetailSerializer
+
+    @action(detail=True, methods=['get'])
+    def emission_factor_types(self, request, pk=None):
+        emission_source_group = self.get_object()
+        emission_factor_types = emission_source_group.emission_factor_types.all()
+        serializer = FactorTypeSerializer(emission_factor_types, many=True)
+        return Response(serializer.data)
 
 
 class BaseSearchViewSet(ListModelMixin, viewsets.GenericViewSet, CreateModelMixin):

--- a/emission_source_classifications/serializers.py
+++ b/emission_source_classifications/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 from emissions.serializers import FactorTypeSerializer
-from .models import QuantificationType, GHGScope, ISOCategory, EmissionSourceGroup, CommonEquipment, CommonActivity, \
-    CommonProduct, Investment
+from .models import QuantificationType, GHGScope, ISOCategory, EmissionSourceGroup, \
+    CommonEquipment, CommonActivity, CommonProduct, Investment
 
 
 class QuantificationTypeSerializer(serializers.ModelSerializer):
@@ -24,16 +24,25 @@ class ISOCategorySerializer(serializers.ModelSerializer):
         fields = ('id', 'name', 'code', 'scope', 'scope_name', 'description')
 
 
-class EmissionSourceGroupSerializer(serializers.ModelSerializer):
+class EmissionSourceGroupBaseSerializer(serializers.ModelSerializer):
     category_name = serializers.CharField(source='category.name', read_only=True)
-    emission_factor_type_names = serializers.StringRelatedField(source='emission_factor_types', many=True)
-    emission_factor_types = FactorTypeSerializer(read_only=True, many=True)
 
     class Meta:
         model = EmissionSourceGroup
         fields = ('id', 'name', 'description', 'icon', 'category', 'category_name',
-                  'emission_factor_types', 'emission_factor_type_names', 'emission_factor_types',
                   'allow_inventory', 'enabled', 'form_name', 'classification')
+
+
+class EmissionSourceGroupListSerializer(EmissionSourceGroupBaseSerializer):
+    class Meta(EmissionSourceGroupBaseSerializer.Meta):
+        pass
+
+
+class EmissionSourceGroupDetailSerializer(EmissionSourceGroupBaseSerializer):
+    emission_factor_type_names = serializers.StringRelatedField(source='emission_factor_types', many=True)
+
+    class Meta(EmissionSourceGroupBaseSerializer.Meta):
+        fields = EmissionSourceGroupBaseSerializer.Meta.fields + ('emission_factor_type_names',)
 
 
 class CommonEquipmentSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
The attributes 'emission_factor_types' and 'emission_factor_type_names' were moved from the general list of the emission source group. Now, only the emission factor type names are shown in the endpoint of each object, and there is a specific endpoint for emission factor types.