### PR TITLE
Feature/logout-without-refresh-token

### DIFF
--- a/accounts/api.py
+++ b/accounts/api.py
@@ -285,11 +285,10 @@ class LogoutAPIView(APIView):
         },
     )
     def post(self, request, *args, **kwargs):
-        try:
-            refresh_token = request.data["refresh_token"]
-            print(refresh_token)
-            token = RefreshToken(refresh_token)
-            token.blacklist()
+        try:            
+            refresh_token = RefreshToken.for_user(request.user)
+            refresh_token.blacklist()
+
             return Response({'detail': _('Sesión cerrada correctamente')}, status=status.HTTP_200_OK)
         except Exception as e:
             return Response({'error': e}, status=status.HTTP_400_BAD_REQUEST)

--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -135,8 +135,7 @@ class TokenOutput(serializers.Serializer): # noqa
 
 
 class LogoutSerializer(serializers.Serializer): # noqa
-    refresh_token = serializers.CharField()
-
+    pass
 
 class GoogleAccountSerializer(serializers.Serializer): # noqa
     token = serializers.CharField()


### PR DESCRIPTION
We needed the frontend to log out without needing to send the refresh token. To achieve this, we created a new refresh token and added it to the blacklist. This was made possible by setting ROTATE_REFRESH_TOKENS to True.